### PR TITLE
feat: bump version omniauth-oauth2 to 1.8.0

### DIFF
--- a/omniauth-marvin.gemspec
+++ b/omniauth-marvin.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'omniauth-oauth2', '1.7.0'
+  spec.add_dependency 'omniauth-oauth2', '1.8.0'
   spec.add_runtime_dependency 'multi_json', '~> 1.15.0'
 
   spec.add_development_dependency 'bundler', '~> 2.2.16'


### PR DESCRIPTION
Hello, in this PR I bumped the version of omniauth-oauth2 to 1.8.0. 